### PR TITLE
Set random seed in carla-bev-v0 env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ stable-baselines3==2.0.0
 torch==1.13.1
 protobuf==3.6.1
 tyro==0.9.1
-carla-birdeye-view @ git+https://github.com/akuramshin/carla-birdeye-view@main
+carla-birdeye-view @ git+https://github.com/akuramshin/carla-birdeye-view@master
 hydra-core==1.3.2
 hydra-joblib-launcher==1.2.0

--- a/src/gym_carla/agents/ppo/ppo.py
+++ b/src/gym_carla/agents/ppo/ppo.py
@@ -100,7 +100,7 @@ def make_env(
     discrete=False,
     discrete_acc=[-3.0, 0.0, 3.0],
     discrete_steer=[-0.2, 0.0, 0.2],
-    continuous_accel_range=[-3.0, 3.0],
+    continuous_accel_range=[-1.0, 1.0],
     continuous_steer_range=[-0.3, 0.3],
     ego_vehicle_filter="vehicle.audi.a2",
     port=4000,
@@ -177,10 +177,10 @@ def run_single_experiment(cfg, seed, save_path, port):
     # device = "cpu"
 
     # TODO: eventually we want many envs!!
-    env = DummyVecEnv([lambda env_name=env_name: make_env(env_name=env_name, town=env_town, port=port) for env_name, env_town, port in [(cfg.env_id, cfg.town, port)]])
+    env = DummyVecEnv([lambda env_name=env_name: make_env(env_name=env_name, town=env_town, port=port, seed=seed) for env_name, env_town, port in [(cfg.env_id, cfg.town, port)]])
     # env = DummyVecEnv([make_env(env_name=cfg.env_id, town=cfg.town)])
     
-    agent = PpoPolicy(env.observation_space, env.action_space).to(device)
+    agent = PpoPolicy(env.observation_space, env.action_space, distribution_kwargs=cfg.agent.distribution_kwargs).to(device)
 
     optimizer = optim.Adam(agent.parameters(), lr=cfg.agent.learning_rate, eps=1e-5)
 

--- a/src/gym_carla/agents/ppo/ppo.py
+++ b/src/gym_carla/agents/ppo/ppo.py
@@ -192,8 +192,8 @@ def run_single_experiment(cfg, seed, save_path):
 
     obs = {}
     for k, s in env.observation_space.spaces.items():
-        obs[k] = torch.zeros((cfg.num_steps, env.num_envs,) + s.shape, dtype=torch.uint8).to(device)
-    actions = torch.zeros((cfg.num_steps, cfg.num_envs) + env.action_space.shape, dtype=torch.float32).to(
+        obs[k] = torch.zeros((cfg.num_steps, env.num_envs,) + s.shape).to(device)
+    actions = torch.zeros((cfg.num_steps, cfg.num_envs) + env.action_space.shape).to(
         device
     )
     logprobs = torch.zeros((cfg.num_steps, cfg.num_envs)).to(device)
@@ -242,7 +242,7 @@ def run_single_experiment(cfg, seed, save_path):
             logprobs[step] = log_prob
 
             next_obs, reward, next_done, infos = env.step(action.cpu().numpy())
-            rewards[step] = torch.tensor(reward).to(device).view(-1)
+            rewards[step] = torch.Tensor(reward).to(device).view(-1)
             next_done = torch.Tensor(next_done).to(device)
 
             print("Step:", step)
@@ -292,7 +292,7 @@ def run_single_experiment(cfg, seed, save_path):
             start_ep = max(len(ep_start_idx)-cfg.save_last_n, 0)
             for i, start_step in enumerate(ep_start_idx[start_ep:]):
                 ep = i+start_ep
-                images = [obs['birdeye'][start_step+j, 0].cpu().numpy() for j in range(ep_lens[ep])]
+                images = [obs['birdeye'][start_step+j, 0].cpu().numpy().astype(np.uint8) for j in range(ep_lens[ep])]
                 width, height = images[0].shape[:2]
                 out = cv2.VideoWriter(f"{save_path}/ep_{ep}.mp4", cv2.VideoWriter_fourcc(*'mp4v'), 10, (width, height))
                 for img in images:

--- a/src/gym_carla/agents/ppo/ppo.py
+++ b/src/gym_carla/agents/ppo/ppo.py
@@ -91,7 +91,7 @@ import hydra
 
 def make_env(
     env_name="carla-bev-v0",
-    number_of_vehicles=100,
+    number_of_vehicles=25,
     number_of_walkers=0,
     display_size=256,
     max_past_step=1,
@@ -101,7 +101,7 @@ def make_env(
     discrete_steer=[-0.2, 0.0, 0.2],
     continuous_accel_range=[-3.0, 3.0],
     continuous_steer_range=[-0.3, 0.3],
-    ego_vehicle_filter="vehicle.lincoln*",
+    ego_vehicle_filter="vehicle.audi.a2",
     port=4000,
     town="Town03",
     task_mode="random",
@@ -116,6 +116,7 @@ def make_env(
     display_route=True,
     pixor_size=64,
     pixor=False,
+    seed=None,
 ):
     """Loads train and eval environments."""
     env_params = {
@@ -144,6 +145,7 @@ def make_env(
         "display_route": display_route,  # whether to render the desired route
         "pixor_size": pixor_size,  # size of the pixor labels
         "pixor": pixor,  # whether to output PIXOR observation
+        "seed": seed,
     }
 
     gym_spec = gym.spec(env_name)

--- a/src/gym_carla/conf/agent/ppo.yaml
+++ b/src/gym_carla/conf/agent/ppo.yaml
@@ -14,3 +14,6 @@ gae_lambda: 0.95
 gamma: 0.99
 anneal_lr: true
 learning_rate: 3e-5
+distribution_kwargs:
+    dist_init: [[0, -0.5], [0, -1.0]]
+    action_dependent_std: true

--- a/src/gym_carla/conf/config.yaml
+++ b/src/gym_carla/conf/config.yaml
@@ -27,3 +27,5 @@ num_envs: 1
 num_steps: 256
 total_timesteps: 40000
 num_iterations: 0
+save_last_n: 2
+save_video: true

--- a/src/gym_carla/envs/carla_bev_env.py
+++ b/src/gym_carla/envs/carla_bev_env.py
@@ -12,14 +12,12 @@ import numpy as np
 import pygame
 import random
 import time
-from skimage.transform import resize
 
 import gym
 from gym import spaces
 from gym.utils import seeding
 import carla
 
-from cv2 import cv2
 from carla_birdeye_view import BirdViewProducer, BirdViewCropType, PixelDimensions
 from gym_carla.envs.route_planner import RoutePlanner
 from gym_carla.envs.misc import *
@@ -72,7 +70,7 @@ class CarlaBEVEnv(gym.Env):
       params['continuous_steer_range'][1]]), dtype=np.float32)  # acc, steer
     observation_space_dict = {
       # 'camera': spaces.Box(low=0, high=255, shape=(self.display_size[0], self.display_size[1], 3), dtype=np.uint8),
-      'birdeye': spaces.Box(low=0, high=1, shape=(self.display_size[0], self.display_size[1], 10), dtype=np.uint8),
+      'birdeye': spaces.Box(low=0, high=255, shape=(self.display_size[0], self.display_size[1], 3), dtype=np.uint8),
       'state': spaces.Box(np.array([-2, -1, -5, 0]), np.array([2, 1, 30, 1]), dtype=np.float32)
       }
     if self.pixor:
@@ -451,10 +449,10 @@ class CarlaBEVEnv(gym.Env):
     birdeye = self.birdeye_render.produce(
         agent_vehicle=self.ego  # carla.Actor (spawned vehicle)
     )
+    birdeye_rgb = BirdViewProducer.as_rgb(birdeye).astype(np.uint8)
 
     # Display birdeye image
     if not self._headless:
-      birdeye_rgb = BirdViewProducer.as_rgb(birdeye).astype("uint8")
       birdeye_surface = rgb_to_display_surface(birdeye_rgb, self.display_size)
       self.display.blit(birdeye_surface, (0, 0))
 
@@ -517,7 +515,7 @@ class CarlaBEVEnv(gym.Env):
 
     obs = {
       # 'camera':camera.astype(np.uint8),
-      'birdeye':birdeye.astype(np.uint8),
+      'birdeye': birdeye_rgb,
       'state': state,
     }
 

--- a/src/gym_carla/envs/carla_bev_env.py
+++ b/src/gym_carla/envs/carla_bev_env.py
@@ -607,7 +607,7 @@ class CarlaBEVEnv(gym.Env):
   def close(self):
     self._clear_all_actors(['sensor.other.collision', 'vehicle.*', 'controller.ai.walker', 'walker.*']) 
     self._world.tick()
-    self.set_sync_mode(False)
+    self._set_synchronous_mode(False)
     self._client = None
     self._world = None
     self._tm = None


### PR DESCRIPTION
- Set random seed for number generation and TrafficManager at env initialization.
- Reduced randomness of what vehicles are spawned by setting them all to be the same.
- Set ego vehicle to be a specific vehicle everytime.
- Reduced default number of vehicles to 25 as higher numbers lead to randomness in spawn points as carla has to decide if a vehicle can be spawned at a specific location or not (which we do not seed). So if we reduce the number of vehicles, we reduce the number of these "collisions" where carla decides that a vehicle cant be spawned somewhere.